### PR TITLE
Fix: access event times as date objects

### DIFF
--- a/client/src/components/Calendar.jsx
+++ b/client/src/components/Calendar.jsx
@@ -173,8 +173,8 @@ const MyCalendar = () => {
             <Calendar
                 localizer={localizer}
                 events={events}
-                startAccessor="start"
-                endAccessor="end"
+                startAccessor={(event) => { return new Date(event.start) } }
+				endAccessor={(event) => { return new Date(event.end) } }
                 selectable
                 onSelectSlot={handleEventCreate}
                 onSelectEvent={handleEventClick}


### PR DESCRIPTION
This fixes the issue in the calendar component (where the event times were being improperly accessed as strings) by accessing the times as date objects.

Fixes #2 